### PR TITLE
migrate to filesUploadV2

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,5 @@
 const { App, LogLevel, AwsLambdaReceiver } = require('@slack/bolt')
 const chromium = require("@sparticuz/chromium")
-const { createReadStream } = require('fs')
 const axios = require('axios')
 const puppeteer = require("puppeteer-core")
 
@@ -85,10 +84,11 @@ const uploadScreenShot = async ({ client, body }) => {
 
   await browser.close()
 
-  await client.files.upload({
-    channels: body['event']['channel'],
+  await client.filesUploadV2({
+    channel_id: body['event']['channel'],
     initial_comment: `Taking screenshot of ${originalUrl}`,
-    file: createReadStream(fileName),
+    file: fileName,
+    filetype: 'png'
   })
 }
 

--- a/local.js
+++ b/local.js
@@ -1,6 +1,5 @@
 const { App } = require('@slack/bolt')
 const chromium = require("@sparticuz/chromium")
-const { createReadStream } = require('fs')
 const axios = require('axios')
 const puppeteer = require("puppeteer-core")
 
@@ -80,10 +79,11 @@ const uploadScreenShot = async ({ client, body }) => {
 
   await browser.close()
 
-  await client.files.upload({
-    channels: body['event']['channel'],
+  await client.filesUploadV2({
+    channel_id: body['event']['channel'],
     initial_comment: `Taking screenshot of ${originalUrl}`,
-    file: createReadStream(fileName),
+    file: fileName,
+    filetype: 'png'
   })
 }
 


### PR DESCRIPTION
slack `files.upload` method is already deprecated and will not be available in the near future.

https://api.slack.com//changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay

> The original web API method for uploading files to Slack, [files.upload](https://api.slack.com/methods/files.upload), is being sunset on March 11, 2025.

-----

this PR contains:
- migrate from `files.upload` to `filesUploadV2`
- pass file path instead of stream to `file` and add `filetype`
  - because image preview does not working when passing data stream to `file`